### PR TITLE
Changes leading zero preference from exclude to include

### DIFF
--- a/src/config/lint/scsslint.yml
+++ b/src/config/lint/scsslint.yml
@@ -67,7 +67,7 @@ linters:
 
   LeadingZero:
     enabled: true
-    style: exclude_zero # or 'include_zero'
+    style: include_zero # or 'exclude_zero'
 
   MergeableSelector:
     enabled: true


### PR DESCRIPTION
## Why?

• SCSS linter should match our guidelines.
• [Reference](http://wiki.smashingboxes.com/articles/sb-css-scss-style-guide)
## What?

• Changes leading zero preference from exclude_zero to include_zero
• Also changes the comment, in the case we would want to change our minds
