### PR TITLE
Build Tweaks

### DIFF
--- a/src/modules/build.coffee
+++ b/src/modules/build.coffee
@@ -7,7 +7,7 @@ fs      = require 'fs'
 module.exports = (Smasher) ->
   {commander, assumptions, user, platform, project, recipes, util, helpers} = Smasher
   {logger, notify, execute, merge, args} = util
-  {files, $, dest, onError, rootPath, pkg, logging} = helpers
+  {files, $, dest, onError, rootPath, pkg, logging, templateReplace} = helpers
   {dir} = project
 
   target        = project.dir?.build
@@ -100,11 +100,10 @@ module.exports = (Smasher) ->
     _js.push css      if css2js
     _js.push html     if html2js
     js = merge _js
-      .pipe $.order project.build.scripts.order
+      .pipe $.order  project.build.scripts.order
       .pipe $.concat JSoutfile
-      .pipe $.ngAnnotate cfg.ngAnnotate
       .pipe $.uglify cfg.uglify
-      .pipe $.if args.cat, $.cat()
+      .pipe $.if     args.cat, $.cat()
 
 
     ### ------------------APP------------------ ###
@@ -123,25 +122,20 @@ module.exports = (Smasher) ->
   Smasher.task 'build:index', ['build:assets'],  ->
     logger.verbose "Injecting built files into #{chalk.magenta 'index.jade'}"
     appFiles = merge [
-      files('build', '.js', true)
-      files('build', '.css', false)
+      files('build', '.js',  true).pipe $.order(project.build.scripts.order)
+      files('build', '.css', false).pipe $.order(project.build.scripts.order)
     ]
 
-    files path:"#{dir.client}/index.jade"
+    templateReplace(files path:"#{dir.client}/index.jade")
       .pipe logging()
-
       .pipe $.inject appFiles,
         name:         'app'
         ignorePath:   dir.build
         addRootSlash: false
-
       .pipe $.if args.cat, $.cat()
-
       .pipe $.jade compileDebug:true
       .on('error', (err) -> logger.error err.message)
-
       .pipe gulp.dest target
-      .pipe logging()
 
   Smasher.task 'build:serve', ->
     $.browserSync

--- a/src/modules/compile.coffee
+++ b/src/modules/compile.coffee
@@ -111,7 +111,7 @@ module.exports = (Smasher) ->
       logger.info "Injecting compiled files into #{chalk.magenta 'index.jade'}"
 
       vendorFiles = files('vendor', '*', false)
-        .pipe $.order(project.build.scripts.order)
+        .pipe $.order(project.compile.scripts.order)
       appFiles = merge [
         files('compile', '.js', true).pipe $.order(project.compile.scripts.order)
         files('compile', '.css', false).pipe $.order(project.compile.styles.order)
@@ -121,11 +121,11 @@ module.exports = (Smasher) ->
         .pipe logging()
         .pipe $.inject appFiles,
           name:         'app'
-          ignorePath:   'compile'
+          ignorePath:   dir.compile
           addRootSlash: false
         .pipe $.inject vendorFiles,
           name:         'vendor'
-          ignorePath:   'client'
+          ignorePath:   dir.client
           addRootSlash: false
         .pipe $.if args.cat, $.cat()
         .pipe $.jade pretty:true, compileDebug:true

--- a/src/recipes/js.coffee
+++ b/src/recipes/js.coffee
@@ -46,8 +46,7 @@ module.exports =
         stream
           .pipe $.stripDebug()
           .pipe $.ngAnnotate cfg.ngAnnotate
-          # .pipe $.angularFilesort()
-
-          # .pipe $.concat outfile
           # .pipe $.uglify cfg.uglify
+          # .pipe $.angularFilesort()
+          # .pipe $.concat outfile
           # .pipe logging()


### PR DESCRIPTION
# WHY?!
- Assets for GiiG Web client were not being concatenated in the correct order at build time
# WHAT CHANGED?!
- Cleaned up some of the Build phase logic to ensure scripts were concatenated in the order defined in the local Smashfile before concatenation
