### PR TITLE
Default to Taperole for deployment and provisioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
     "pretty-error": "^1.1.1",
     "prompt": "~0.2.14",
     "q": "^1.1.2",
-    "shelljs": "^0.5.1",
     "stream-to-promise": "^1.0.4",
     "streamqueue": "^1.1.0",
     "style-loader": "^0.12.3",


### PR DESCRIPTION
# Why?
- When using tape for a multi-stage environment, I live in constant fear of accidentally deploying/re-provisioning an environment I didn't mean to by forgetting the `--limit` argument
# What Changed?
- Adds `smash provision` command that wraps `tape ansible everything`
- Modifies `smash deploy` to assume Taperole by default
- Removes `shelljs` dependency since it was not being used
