### PR TITLE
Append file hash to filename on build (JS only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "gulp-remember": "^0.3.0",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "~0.5.3",
+    "gulp-rev-all": "^0.8.24",
     "gulp-sass": "^2.0.1",
     "gulp-scss-lint": "^0.2.0",
     "gulp-sourcemaps": "^1.3.0",

--- a/src/modules/build.coffee
+++ b/src/modules/build.coffee
@@ -32,6 +32,8 @@ module.exports = (Smasher) ->
       mangle: false
       preserveComments: 'some'
 
+  revAll = new $.revAll()
+
   Smasher.on 'clean', -> Smasher.startTask 'build:clean'
 
   ### ---------------- COMMANDS ------------------------------------------- ###
@@ -104,6 +106,7 @@ module.exports = (Smasher) ->
       .pipe $.concat JSoutfile
       .pipe $.uglify cfg.uglify
       .pipe $.if     args.cat, $.cat()
+      .pipe revAll.revision()
 
 
     ### ------------------APP------------------ ###


### PR DESCRIPTION
# Why?
- To help with caching issues for SPAs that build to a single JS file
# What Changed?
- Added `gulp-rev-all` to the JS asset stream to automatically append a file hash to the filename and update any references to renamed files
